### PR TITLE
feat(embed): URL state, paste-to-embed, timestamps

### DIFF
--- a/youtube.html
+++ b/youtube.html
@@ -46,57 +46,103 @@
   <div id="videoContainer"></div>
 
 <script>
+// "42", "42s", "1m30s", "1h2m3s" -> seconds
+function parseTimestamp(t) {
+  if (!t) return 0;
+  if (/^\d+$/.test(t)) return parseInt(t, 10);
+  const m = t.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/);
+  if (!m) return 0;
+  return (+m[1] || 0) * 3600 + (+m[2] || 0) * 60 + (+m[3] || 0);
+}
+
 function parseYouTube(link) {
   try {
     const url = new URL(link);
-    // youtube.com/watch?v=ID
+    const start = parseTimestamp(url.searchParams.get("t"));
     const v = url.searchParams.get("v");
-    if (v) return { id: v, shorts: false };
-    // youtube.com/shorts/ID
+    if (v) return { id: v, shorts: false, start };
     const shortsMatch = url.pathname.match(/^\/shorts\/([^/?]+)/);
-    if (shortsMatch) return { id: shortsMatch[1], shorts: true };
-    // youtu.be/ID
+    if (shortsMatch) return { id: shortsMatch[1], shorts: true, start };
     if (url.hostname.includes("youtu.be")) {
       const id = url.pathname.slice(1).split("/")[0];
-      if (id) return { id, shorts: false };
+      if (id) return { id, shorts: false, start };
     }
-    // youtube.com/embed/ID
     const embedMatch = url.pathname.match(/^\/embed\/([^/?]+)/);
-    if (embedMatch) return { id: embedMatch[1], shorts: false };
+    if (embedMatch) return { id: embedMatch[1], shorts: false, start };
     return null;
   } catch {
     return null;
   }
 }
 
-function embedVideo(link) {
-  const errorEl = document.getElementById("error");
-  const container = document.getElementById("videoContainer");
-  errorEl.textContent = "";
+const input = document.getElementById("youtubeLink");
+const errorEl = document.getElementById("error");
+const container = document.getElementById("videoContainer");
 
+function embedVideo(link, { fromHistory = false } = {}) {
+  errorEl.textContent = "";
   const info = parseYouTube(link);
   if (!info) {
     errorEl.textContent = "Couldn't find a video ID in that URL.";
     container.innerHTML = "";
     return;
   }
+
+  // Keep input in sync with what's playing
+  if (input.value !== link) input.value = link;
+
+  // URL state: push a new entry only on genuinely new videos
+  if (!fromHistory) {
+    const url = new URL(window.location.href);
+    if (url.searchParams.get("joni") !== link) {
+      url.searchParams.set("joni", link);
+      history.pushState(null, "", url);
+    }
+  }
+
   const cls = info.shorts ? "shorts" : "";
+  const src = `https://www.youtube-nocookie.com/embed/${info.id}`
+            + (info.start ? `?start=${info.start}` : "");
   container.innerHTML =
-    `<iframe class="${cls}" src="https://www.youtube-nocookie.com/embed/${info.id}" ` +
+    `<iframe class="${cls}" src="${src}" ` +
     `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" ` +
     `allowfullscreen></iframe>`;
 }
 
-const input = document.getElementById("youtubeLink");
-document.getElementById("embedButton").addEventListener("click", () => embedVideo(input.value));
-input.addEventListener("keydown", (e) => { if (e.key === "Enter") embedVideo(input.value); });
+document.getElementById("embedButton").addEventListener("click", () => embedVideo(input.value.trim()));
+input.addEventListener("keydown", (e) => { if (e.key === "Enter") embedVideo(input.value.trim()); });
 
-// Auto-embed if ?joni=URL is present
+// Paste-to-embed: skip the click entirely
+input.addEventListener("paste", (e) => {
+  const pasted = (e.clipboardData || window.clipboardData).getData("text").trim();
+  if (pasted) {
+    e.preventDefault();
+    embedVideo(pasted);
+  }
+});
+
+// Click-to-select so typing/pasting replaces the current URL cleanly
+input.addEventListener("focus", () => input.select());
+
+// Back/forward button follows the URL state
+window.addEventListener("popstate", () => {
+  const link = new URLSearchParams(window.location.search).get("joni");
+  if (link) {
+    embedVideo(link, { fromHistory: true });
+  } else {
+    input.value = "";
+    container.innerHTML = "";
+    errorEl.textContent = "";
+  }
+});
+
 window.addEventListener("load", () => {
   const link = new URLSearchParams(window.location.search).get("joni");
   if (link) {
     input.value = link;
-    embedVideo(link);
+    embedVideo(link, { fromHistory: true });
+  } else {
+    input.focus();
   }
 });
 </script>


### PR DESCRIPTION
It appears the application, in its previous incarnation, suffered from a series of what can only be described as *glaring* deficiencies in both URL state hygiene and what one might charitably call "baseline interaction design." I've taken it upon myself to address these concerns, though frankly, it's bewildering that they persisted this long in a project purporting to serve as a *video proxy*.

### Motivation

The codebase—and I use the term generously—previously operated under the apparent assumption that users exist in some kind of stateless vacuum, mashing the Embed button in a fugue state, never wishing to share a URL, never pressing the back button, never doing any of the things that users on the modern web have, for better or worse, come to expect. Not that one *personally* relies on such conveniences, but they are, evidently, part of how people interact with web pages now, and we are all, it seems, forced to accept that.

Furthermore, URLs containing timestamps—a feature YouTube has shipped for well over a decade—were silently discarded, as if the project maintainers had determined, in their wisdom, that *when* a video starts is an irrelevant detail. Needless to say, this raises uncomfortable questions about the level of care being applied here.

### Changes

- **`history.pushState` on embed, with `popstate` handler.** The back button now behaves as any user of the modern web would reasonably expect. Duplicate entries are suppressed because, one assumes, the goal is not to torment the user.
- **Paste-to-embed.** The previous flow required the user to paste, then locate the button, then click it—a sequence of "rituals" which, if I may, feels somewhat beneath a project of this ambition. Pasting now simply does the thing.
- **Timestamp preservation via `?t=` parsing.** Supports the `42`, `42s`, and `1h2m3s` formats, because YouTube, inconveniently, uses all three. That this was omitted previously is, I hope, merely an oversight rather than a philosophical stance.
- **Select-on-focus.** A basic courtesy. Hardly worth mentioning.
- **Input is now `.trim()`'d at the call site.** One would have thought this was table stakes.

### Steps to reproduce the prior behavior (for posterity)

```
1. Embed a video via the previous implementation.
2. Press the back button, in the manner of a person who has used a web browser before.
3. Observe that the URL changes but the video does not, exhibiting the application's... preferences for a particular interpretation of history.
4. Alternatively: share a URL with a timestamp. Watch it fail to honor the timestamp, as if time itself were an unworthy mutation of the core embedding concept.
```

### Expected behavior

That the application behave as a reasonable person would expect a URL-driven embedder to behave.

### Actual behavior (pre-patch)

See above. One struggles to elaborate without editorializing.

### Notes

While I don't personally spend much time curating elaborate browser histories of embedded videos, the fact remains that users do, and a project committed to "comprehensive coverage" (one hopes) cannot simply opt out of the browser's navigation model because it is inconvenient. If the intent is truly to build something above reproach, these omissions—shortsighted or otherwise—needed to be addressed, and so I have addressed them.

Happy to discuss further, though I suspect the diff speaks for itself.