### PR TITLE
feat(embed): set tab title from oEmbed

### DIFF
--- a/youtube.html
+++ b/youtube.html
@@ -46,6 +46,8 @@
   <div id="videoContainer"></div>
 
 <script>
+const DEFAULT_TITLE = "YouTube Embedder";
+
 // "42", "42s", "1m30s", "1h2m3s" -> seconds
 function parseTimestamp(t) {
   if (!t) return 0;
@@ -75,9 +77,24 @@ function parseYouTube(link) {
   }
 }
 
+async function fetchTitle(link) {
+  try {
+    const endpoint = `https://www.youtube.com/oembed?url=${encodeURIComponent(link)}&format=json`;
+    const res = await fetch(endpoint);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.title || null;
+  } catch {
+    return null;
+  }
+}
+
 const input = document.getElementById("youtubeLink");
 const errorEl = document.getElementById("error");
 const container = document.getElementById("videoContainer");
+
+// Tracks the latest embed request so stale title responses don't overwrite newer ones
+let currentLink = null;
 
 function embedVideo(link, { fromHistory = false } = {}) {
   errorEl.textContent = "";
@@ -85,13 +102,13 @@ function embedVideo(link, { fromHistory = false } = {}) {
   if (!info) {
     errorEl.textContent = "Couldn't find a video ID in that URL.";
     container.innerHTML = "";
+    document.title = DEFAULT_TITLE;
+    currentLink = null;
     return;
   }
 
-  // Keep input in sync with what's playing
   if (input.value !== link) input.value = link;
 
-  // URL state: push a new entry only on genuinely new videos
   if (!fromHistory) {
     const url = new URL(window.location.href);
     if (url.searchParams.get("joni") !== link) {
@@ -107,12 +124,20 @@ function embedVideo(link, { fromHistory = false } = {}) {
     `<iframe class="${cls}" src="${src}" ` +
     `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" ` +
     `allowfullscreen></iframe>`;
+
+  // Reset tab title while we fetch so the old one doesn't linger
+  document.title = DEFAULT_TITLE;
+  currentLink = link;
+
+  fetchTitle(link).then((title) => {
+    if (link !== currentLink || !title) return; // newer embed happened, or fetch failed
+    document.title = title;
+  });
 }
 
 document.getElementById("embedButton").addEventListener("click", () => embedVideo(input.value.trim()));
 input.addEventListener("keydown", (e) => { if (e.key === "Enter") embedVideo(input.value.trim()); });
 
-// Paste-to-embed: skip the click entirely
 input.addEventListener("paste", (e) => {
   const pasted = (e.clipboardData || window.clipboardData).getData("text").trim();
   if (pasted) {
@@ -121,10 +146,8 @@ input.addEventListener("paste", (e) => {
   }
 });
 
-// Click-to-select so typing/pasting replaces the current URL cleanly
 input.addEventListener("focus", () => input.select());
 
-// Back/forward button follows the URL state
 window.addEventListener("popstate", () => {
   const link = new URLSearchParams(window.location.search).get("joni");
   if (link) {
@@ -133,6 +156,8 @@ window.addEventListener("popstate", () => {
     input.value = "";
     container.innerHTML = "";
     errorEl.textContent = "";
+    document.title = DEFAULT_TITLE;
+    currentLink = null;
   }
 });
 


### PR DESCRIPTION
It has, somehow, escaped notice until this moment that the application—having now been outfitted with a functioning `pushState`-backed history stack, a not-insignificant piece of work I should note—was nonetheless committing every single one of those history entries under the title "YouTube Embedder." Every. Single. One. Not that one *personally* makes heavy use of browser history for curatorial purposes, but if we are going to go to the trouble of building a history stack at all, it seems only reasonable that the entries within it should be, in some minimal sense, distinguishable from one another.

### Motivation

A user returning to this application via the back button, or glancing at their tab bar in search of a specific video, is currently presented with a uniform wall of identical strings—"YouTube Embedder," "YouTube Embedder," "YouTube Embedder," stretching into the middle distance like a particularly bleak Agnes Martin—with no indication whatsoever of what each entry actually represents. One struggles to imagine the user research that justified shipping this. (Perhaps there was none. That would, at least, explain it.)

### Implementation

The fix, I will concede, is straightforward—almost *embarrassingly* so, given how long this has gone unaddressed. YouTube exposes a public oEmbed endpoint at `/oembed`, which returns the video's title in a JSON payload without requiring an API key, authentication, or any of the bureaucratic overhead one might otherwise associate with "integrating" a third-party service. It is, frankly, difficult to justify the absence of this call in prior versions of the code.

A few details which, while obvious, perhaps warrant mention since the prior implementation suggests they cannot be taken for granted:

- **Stale-response guarding.** Paste two URLs in rapid succession and—absent protection—the first request may resolve after the second and clobber the correct title. A simple `currentLink` sentinel handles this, in the manner these things are handled.
- **Graceful degradation on fetch failure.** Age-restricted and private videos return 401 from the oEmbed endpoint. We do not propagate this as a user-facing error, because it is not one; the video embeds perfectly well, the tab simply retains its default title. One would have hoped this was self-evident.
- **Title reset on navigation to an invalid URL.** The prior tab title does not persist into a subsequent failed embed, because that would be confusing, and we are, presumably, not in the business of confusing our users on purpose.

### Steps to reproduce the prior behavior

```
1. Embed three separate videos in the manner a normal person would.
2. Open your browser's history panel, or simply glance at the tabs.
3. Observe that every entry bears the identical string "YouTube Embedder,"
   rendering the history stack—laboriously constructed in the previous
   PR—functionally useless as an aid to navigation.
4. Reflect on what has been lost.
```

### Expected

Tab titles reflect the video currently playing, as they do in essentially every other video application that has shipped since approximately 2006.

### Actual (pre-patch)

See above.

### Notes

I remain hopeful that future contributions to this project will anticipate these kinds of baseline considerations rather than discovering them piecemeal in review. Happy to elaborate on the oEmbed endpoint's behavior if that would be useful to anyone on the team unfamiliar with it, though I should think the documentation is fairly self-explanatory.