### PR TITLE
feat(embed): OG tags for link previews

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -5,6 +5,11 @@
 
 export async function onRequest(context) {
   const url = new URL(context.request.url);
+
+  // Scope: only act on the embedder page
+  if (!url.pathname.endsWith("/youtube.html") && url.pathname !== "/youtube") {
+    return context.next();
+  }
   const videoLink = url.searchParams.get("joni");
 
   // Always fetch the static HTML first

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,88 @@
+// functions/_middleware.js
+// Runs on every request to Cloudflare Pages. If the URL has ?joni=,
+// fetches the video's oEmbed metadata and injects OpenGraph tags into
+// the HTML so Discord/iMessage/Twitter/Slack can render a preview.
+
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  const videoLink = url.searchParams.get("joni");
+
+  // Always fetch the static HTML first
+  const response = await context.next();
+
+  if (!videoLink) return response;
+
+  const videoId = extractVideoId(videoLink);
+  if (!videoId) return response;
+
+  // oEmbed is public, no API key needed
+  let oembedData;
+  try {
+    const oembed = await fetch(
+      `https://www.youtube.com/oembed?url=${encodeURIComponent(videoLink)}&format=json`
+    );
+    if (!oembed.ok) return response;
+    oembedData = await oembed.json();
+  } catch {
+    return response;
+  }
+
+  const title = oembedData.title || "YouTube";
+  const author = oembedData.author_name || "";
+  const thumbnail = oembedData.thumbnail_url || "";
+  const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+  const description = author ? `by ${author}` : "";
+
+  const ogTags = `
+    <meta property="og:title" content="${escape(title)}">
+    <meta property="og:description" content="${escape(description)}">
+    <meta property="og:type" content="video.other">
+    <meta property="og:image" content="${escape(thumbnail)}">
+    <meta property="og:video" content="${escape(embedUrl)}">
+    <meta property="og:video:secure_url" content="${escape(embedUrl)}">
+    <meta property="og:video:type" content="text/html">
+    <meta property="og:video:width" content="1280">
+    <meta property="og:video:height" content="720">
+    <meta name="twitter:card" content="player">
+    <meta name="twitter:title" content="${escape(title)}">
+    <meta name="twitter:image" content="${escape(thumbnail)}">
+    <meta name="twitter:player" content="${escape(embedUrl)}">
+    <meta name="twitter:player:width" content="1280">
+    <meta name="twitter:player:height" content="720">
+  `;
+
+  return new HTMLRewriter()
+    .on("title", {
+      element(el) { el.setInnerContent(title); }
+    })
+    .on("head", {
+      element(el) { el.append(ogTags, { html: true }); }
+    })
+    .transform(response);
+}
+
+function extractVideoId(link) {
+  try {
+    const u = new URL(link);
+    const v = u.searchParams.get("v");
+    if (v) return v;
+    const shorts = u.pathname.match(/^\/shorts\/([^/?]+)/);
+    if (shorts) return shorts[1];
+    if (u.hostname.includes("youtu.be")) {
+      return u.pathname.slice(1).split("/")[0] || null;
+    }
+    const embed = u.pathname.match(/^\/embed\/([^/?]+)/);
+    if (embed) return embed[1];
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function escape(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}


### PR DESCRIPTION
It has, at long last, come to my attention that URLs produced by this application — URLs which, one assumes, are meant to be *shared*, given that an entire `pushState` history stack and an oEmbed-hydrated tab title have now been built atop the premise of shareability — unfurl in Discord, iMessage, Slack, and every other conceivable surface as... nothing. A blank grey rectangle. The string "YouTube Embedder" if one is very lucky. A sort of digital tumbleweed.

I will concede that this is not, strictly speaking, the application's *fault*. The OpenGraph specification predates most of the people writing frontend code today, and it requires — *requires*, @AxelThorAsp — that the relevant `<meta>` tags be present in the initial HTML response. Crawlers do not execute JavaScript. They have never executed JavaScript. This is not a controversial claim. And yet, somehow, we have shipped a video-sharing tool whose shared URLs communicate nothing whatsoever about the videos they contain. One wonders what, exactly, we thought we were doing.

### Motivation

It should be, but apparently is not, self-evident that a URL ending in `?joni=...` ought to produce a preview containing — at absolute *minimum* — the video's title, its thumbnail, and ideally an embedded player. This is a solved problem. It has been a solved problem since approximately 2010. That we are solving it now, in a codebase that has otherwise been refined to a rather high standard (as I think the recent commit history makes abundantly clear), is... well. I won't belabor it.

### Implementation

The patch introduces a Cloudflare Pages Function at `functions/_middleware.js` which intercepts each request, extracts the `?joni=` parameter, hits YouTube's public oEmbed endpoint, and uses Cloudflare's built-in `HTMLRewriter` to inject the appropriate OpenGraph and Twitter Card meta tags into the outgoing `<head>`. It is, I want to emphasize, roughly sixty lines of code. *Sixty.* It streams, it requires no build step, it has zero dependencies. There is no reason — none that survives casual scrutiny — that this did not exist from the outset.

The client-side flow is entirely unchanged. The middleware enriches only the *initial* HTML response, which is, obviously, the only part of the response that link-preview crawlers actually consume. One would have hoped this was understood going in.

### ⚠️ Deployment — action required from @AxelThorAsp

Dropping the voice for this part because it genuinely matters that it gets done right. The middleware cannot run on GitHub Pages — GitHub Pages is a static file server and does not execute code. You'll need to migrate the deployment to **Cloudflare Pages**, which is free, connects to the same repo, and redeploys on every push exactly like GitHub Pages does. Here's the full walkthrough:

1. Sign up at https://dash.cloudflare.com (free tier is fine, no card required).
2. Left sidebar → **Workers & Pages** → **Create** → **Pages** tab → **Connect to Git**.
3. Authorize Cloudflare for GitHub and select this repo.
4. On the build settings screen: **Framework preset** = None, **Build command** = blank, **Build output directory** = `/` (or the subdirectory containing `embed.html` if it's not at the root). Click **Save and Deploy**.
5. After ~30 seconds you'll have a live URL at `<project-name>.pages.dev`. The `functions/_middleware.js` in this PR activates automatically — Cloudflare Pages picks up the `functions/` folder with no further config.
6. **Custom domain** (if you use one): Project → **Custom domains** → **Set up a custom domain**. If the DNS for the domain is already on Cloudflare, it's one click. If it's on another registrar, add a CNAME record there pointing at `<project-name>.pages.dev`, then disable the custom domain on GitHub Pages so the two hosts don't fight.
7. Verify: send yourself a `?joni=...` link in Discord or iMessage. You should see the video's thumbnail, title, and — on Discord specifically — inline playback.

Happy to hop on a call and do this together if any step is unclear.

### Expected

Shared URLs unfurl with the actual video's title, thumbnail, and player — the way any link shared anywhere else on the internet has behaved for over a decade.

### Actual (pre-patch)

A blank grey rectangle. A small sad void. Not, I think we can agree, ideal.

### Notes

Once this is deployed I suspect it will become immediately and somewhat embarrassingly obvious why this should have been the baseline from day one. Looking forward to merging.

Thanks.