### PR TITLE
feat(embed): autoplay

### DIFF
--- a/youtube.html
+++ b/youtube.html
@@ -118,8 +118,8 @@ function embedVideo(link, { fromHistory = false } = {}) {
   }
 
   const cls = info.shorts ? "shorts" : "";
-  const src = `https://www.youtube-nocookie.com/embed/${info.id}`
-            + (info.start ? `?start=${info.start}` : "");
+  const src = `https://www.youtube-nocookie.com/embed/${info.id}?autoplay=1`
+            + (info.start ? `&start=${info.start}` : "");
   container.innerHTML =
     `<iframe class="${cls}" src="${src}" ` +
     `allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" ` +


### PR DESCRIPTION
It has, with some reluctance, come to my attention that upon opening a shared URL, the application — in what I can only presume is a gesture of misplaced modesty — declines to actually play the video. It merely *presents* it, in the manner of a butler gesturing silently toward a covered dish, waiting for the user to give some further signal that yes, in fact, they would like the thing they explicitly clicked a link to receive.

One struggles to reconstruct the reasoning. A user pastes a YouTube URL, or receives one, or clicks one — in every conceivable case, the expressed intent is to *watch the video*. To then require a second, redundant click on the play button is to ask the user to re-affirm a preference they have already, quite clearly, affirmed. It is the digital equivalent of a waiter bringing you the entrée and then waiting, expectantly, for you to confirm that you would indeed like to eat it.

### Motivation

Videos should play. This is not, I think, a radical stance.

### Implementation

A single parameter — `autoplay=1` — appended to the embed URL. One could, I suppose, call it a "change." The diff, should anyone wish to scrutinize it, is approximately nine characters of meaningful text, spread across a line that was already doing most of the work. It has taken us, collectively, several PRs of increasingly sophisticated infrastructure — URL state management, oEmbed hydration, OpenGraph meta injection via a Cloudflare Pages Function — to arrive at the point where we now, finally, permit the video to begin playing. The proportions here are worth reflecting on.

I've also flipped the query separator on the `start` param from `?` to `&`, because — and I apologize in advance for the pedantry — a URL cannot contain two `?`s. This is, it turns out, specified in RFC 3986, a document which has been publicly available since January 2005.

### A note on browser autoplay policies

Modern browsers — Safari with particular zeal — block autoplay-with-sound on page loads where the user has not yet interacted with the page. This is a policy decision by the browser vendors, not a bug in this application, and I will not be accepting further correspondence suggesting otherwise. The practical consequence:

- User pastes a URL or clicks Embed: plays, with sound. As intended.
- User opens a freshly-shared `?joni=...` link for the first time: may be blocked on Safari/Firefox, requiring a single click on the play button.

If we ever decide this is unacceptable and wish to guarantee autoplay across all browsers, the fix is `&mute=1`, which trades "sound on first load" for "guaranteed playback." I have elected *not* to include this, on the grounds that muted autoplay — a video playing silently, with subtitles one did not request, in the corner of one's screen — is perhaps the single most aesthetically bankrupt interaction pattern the modern web has produced, and I would sooner ship nothing at all.

### Expected

The video plays.

### Actual (pre-patch)

The video does not play, and instead sits there, *waiting*, in a manner I find increasingly difficult to describe without editorializing.

### Notes

Merging this brings us, at long last, to something approaching the experience any reasonable user would have assumed they were getting from the outset. I remain guardedly optimistic.